### PR TITLE
Fix pawn movement and piece upgrade logic

### DIFF
--- a/src/features/game/components/ui/UI.module.scss
+++ b/src/features/game/components/ui/UI.module.scss
@@ -6,6 +6,7 @@ $gameOverWidth: 100vw;
   height: 100vh;
   position: absolute;
   z-index: theme.$z-ind-game-ui;
+  pointer-events: none;
 }
 
 .touchArea {
@@ -30,6 +31,7 @@ $gameOverWidth: 100vw;
   text-align: center;
   word-spacing: -0.2rem;
   text-shadow: 0 0 0.5rem black;
+  pointer-events: auto;
 
   animation: slideUp 2s cubic-bezier(0.25, 1, 0.5, 1);
   span.gameOverText {
@@ -129,6 +131,7 @@ $gameOverWidth: 100vw;
   top: 0;
   display: flex;
   flex-direction: row;
+  pointer-events: auto;
 }
 
 .upperCenter {
@@ -175,6 +178,7 @@ $gameOverWidth: 100vw;
   display: flex;
   gap: 1rem;
   z-index: 100;
+  pointer-events: auto;
 }
 
 .upgradeButton {


### PR DESCRIPTION
Enable piece movement by adjusting UI `pointer-events` to allow clicks to reach the game board.

The game board was not receiving click events because a full-screen HUD overlay was intercepting them. This change sets `pointer-events: none` on the main HUD wrapper, allowing clicks to pass through to elements beneath it, specifically the game board. `pointer-events: auto` was then explicitly re-enabled for interactive UI elements like the game over screen, top-right buttons, and the upgrade button to ensure they remain functional.

---
<a href="https://cursor.com/background-agent?bcId=bc-60e660af-b4ef-4e7e-bb30-9c0323d73936">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60e660af-b4ef-4e7e-bb30-9c0323d73936">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

